### PR TITLE
fixed list widgets indexing issue

### DIFF
--- a/src/configure.cpp
+++ b/src/configure.cpp
@@ -175,6 +175,6 @@ void configure::changePage(QListWidgetItem *current, QListWidgetItem *previous)
 
     // 임시방
 
-    ui->stackedWidget->setCurrentIndex(ui->listWidget->row(current)+2);
+    ui->stackedWidget->setCurrentIndex(ui->listWidget->row(current));
 }
 

--- a/src/configure.ui
+++ b/src/configure.ui
@@ -164,8 +164,6 @@
    <property name="frameShape">
     <enum>QFrame::Box</enum>
    </property>
-   <widget class="QWidget" name="page_3"/>
-   <widget class="QWidget" name="page_4"/>
   </widget>
  </widget>
  <tabstops>


### PR DESCRIPTION
Hi, this is Simon (simow at qt.io).
This PR should fix the index issues.

- removed the two empty pages from the stacked widget
- remoted the +2 offset